### PR TITLE
Admin Menu Entry without parent

### DIFF
--- a/src/Sources/AdminMenu.php
+++ b/src/Sources/AdminMenu.php
@@ -16,6 +16,9 @@ class AdminMenu extends Base {
 		);
 
 		foreach ( $submenu as $parentMenu => $submenuItems ) {
+			if ( ! isset( $this->items[ $parentMenu ] ) {
+				continue;
+			}
 			$this->addSubmenuItems( $parentMenu, $submenuItems );
 		}
 	}

--- a/src/Sources/AdminMenu.php
+++ b/src/Sources/AdminMenu.php
@@ -16,7 +16,7 @@ class AdminMenu extends Base {
 		);
 
 		foreach ( $submenu as $parentMenu => $submenuItems ) {
-			if ( ! isset( $this->items[ $parentMenu ] ) {
+			if ( ! isset( $this->items[ $parentMenu ] ) ) {
 				continue;
 			}
 			$this->addSubmenuItems( $parentMenu, $submenuItems );


### PR DESCRIPTION
As a hack, to have an admin page that don't appear in Admin Menu, add_submenu_page is called with parent_slug = null and menu_title = '', so $parentMenu is "" and generate a notice on line 45 (addSubmenuItems)